### PR TITLE
fix(payments): root-reconcile stale iOS receipts instead of 422

### DIFF
--- a/app/Console/Commands/ReconcileHockeyListings.php
+++ b/app/Console/Commands/ReconcileHockeyListings.php
@@ -63,8 +63,46 @@ class ReconcileHockeyListings extends Command
             }
         });
 
+        // Phase 2 — safety net for paid-but-unpublished listings: any SUCCESS
+        // transaction whose owning request maps (via meta.listing_id) to a listing
+        // that never flipped to published, including transactions recorded against a
+        // now-superseded request. Idempotent: skips already-published / missing
+        // (soft-deleted) listings. This catches any drift the live root-reconcile
+        // path could miss (e.g. a crash between recording the txn and publishing).
+        $stranded = 0;
+        V4PaymentTransaction::where('status', V4PaymentTransaction::STATUS_SUCCESS)
+            ->where('created_at', '>=', now()->subDays(30)) // bound the recurring scan
+            ->chunkById(200, function ($txns) use ($apply, &$stranded) {
+                foreach ($txns as $txn) {
+                    $request = V4PaymentRequest::find($txn->payment_request_id);
+                    if (!$request) {
+                        continue;
+                    }
+                    $listingId = data_get($request->meta, 'listing_id');
+                    $listing = $listingId ? V4HockeyListing::find($listingId) : null;
+                    if (!$listing || $listing->status === V4HockeyListing::STATUS_PUBLISHED) {
+                        continue;
+                    }
+                    $stranded++;
+                    if (!$apply) {
+                        continue;
+                    }
+                    DB::transaction(function () use ($request, $listing) {
+                        // Re-read the listing under a row lock so a concurrent live
+                        // confirm / root-reconcile cannot double-publish or clobber
+                        // listed_at. Skip if it was published in the meantime.
+                        $locked = V4HockeyListing::whereKey($listing->id)->lockForUpdate()->first();
+                        if (!$locked || $locked->status === V4HockeyListing::STATUS_PUBLISHED) {
+                            return;
+                        }
+                        $request->markPaid();
+                        $locked->markPublished();
+                    });
+                }
+            });
+
         $mode = $apply ? 'APPLIED' : 'DRY-RUN';
-        $this->info("[$mode] publish={$counts['publish']} release={$counts['release']} skip={$counts['skip']}");
+        $this->info("[$mode] publish={$counts['publish']} release={$counts['release']} skip={$counts['skip']} stranded_published={$stranded}");
         return self::SUCCESS;
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -34,6 +34,11 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command('chat:unmute-expired')->hourly();
+
+        // Self-heal hockey listings stuck by stranded/replayed store receipts.
+        $schedule->command('hockey:reconcile-listings --apply')
+            ->everyFifteenMinutes()
+            ->withoutOverlapping();
     }
 
     /**

--- a/app/Services/Payments/HockeyListingPaymentDecider.php
+++ b/app/Services/Payments/HockeyListingPaymentDecider.php
@@ -33,17 +33,63 @@ class HockeyListingPaymentDecider
     public const RECON_RELEASE = 'release';
     public const RECON_SKIP    = 'skip';
 
+    // root-reconcile outcomes for a receipt bound to a DIFFERENT request than the
+    // one currently being confirmed (see bindingReconcile()).
+    public const RECON_BIND_PUBLISH   = 'reconcile_publish';
+    public const RECON_BIND_DUPLICATE = 'reconcile_duplicate';
+    public const RECON_BIND_ORPHAN    = 'orphan_receipt';
+
+    /**
+     * Normalize a binding token / appAccountToken for comparison and lookup.
+     * StoreKit round-trips the appAccountToken UUID and may change its case, so
+     * tokens are compared and stored case-insensitively (lowercased). Empty /
+     * whitespace-only tokens normalize to null (cannot bind).
+     */
+    public function normalizeToken(?string $token): ?string
+    {
+        if ($token === null) {
+            return null;
+        }
+        $token = strtolower(trim($token));
+        return $token === '' ? null : $token;
+    }
+
     /**
      * True when a StoreKit2 receipt's appAccountToken is present and does not
      * match the payment request it is being confirmed against. A missing token on
      * either side cannot bind (legacy/pre-feature receipts) and is NOT a mismatch.
+     * Comparison is case-insensitive (Apple may upper/lower-case the UUID).
      */
     public function bindingMismatch(?string $receiptToken, ?string $requestToken): bool
     {
-        if (empty($receiptToken) || empty($requestToken)) {
+        $receiptToken = $this->normalizeToken($receiptToken);
+        $requestToken = $this->normalizeToken($requestToken);
+        if ($receiptToken === null || $requestToken === null) {
             return false;
         }
-        return !hash_equals((string) $requestToken, (string) $receiptToken);
+        return !hash_equals($requestToken, $receiptToken);
+    }
+
+    /**
+     * Decide how to reconcile a receipt whose appAccountToken belongs to a
+     * payment request OTHER than the one on the current screen. The receipt is a
+     * real Apple charge bound (via appAccountToken == binding_token) to its owning
+     * request; rather than reject it (which loops forever), publish the listing it
+     * actually paid for, absorb duplicates idempotently, or — if no request/listing
+     * owns the token — acknowledge it as orphaned (loop ends; flag for refund).
+     *
+     * @param array $c owner_found, owner_listing_exists, owner_listing_published,
+     *                 owner_success_txn_exists
+     */
+    public function bindingReconcile(array $c): string
+    {
+        if (!($c['owner_found'] ?? false) || !($c['owner_listing_exists'] ?? false)) {
+            return self::RECON_BIND_ORPHAN;
+        }
+        if (($c['owner_listing_published'] ?? false) || ($c['owner_success_txn_exists'] ?? false)) {
+            return self::RECON_BIND_DUPLICATE;
+        }
+        return self::RECON_BIND_PUBLISH;
     }
 
     public function gatewayForSource(string $source): string

--- a/app/Services/Payments/HockeyListingPaymentService.php
+++ b/app/Services/Payments/HockeyListingPaymentService.php
@@ -8,7 +8,10 @@ use App\Models\V4PaymentRequest;
 use App\Models\V4PaymentTransaction;
 use App\Models\V4User;
 use App\Services\Payments\Sk2ReceiptDecoder;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use LogicException;
 
 class HockeyListingPaymentService
@@ -72,7 +75,7 @@ class HockeyListingPaymentService
                 'status' => $isChild
                     ? V4PaymentRequest::STATUS_PENDING
                     : V4PaymentRequest::STATUS_PAYMENT_INITIATED,
-                'binding_token' => (string) \Illuminate\Support\Str::uuid(),
+                'binding_token' => strtolower((string) Str::uuid()),
                 'meta' => ['purpose' => 'hockey_listing', 'listing_id' => $listing->id],
             ];
             if ($isChild) {
@@ -118,7 +121,7 @@ class HockeyListingPaymentService
     public function ensureBindingToken(V4PaymentRequest $request): string
     {
         if (empty($request->binding_token)) {
-            $request->binding_token = (string) \Illuminate\Support\Str::uuid();
+            $request->binding_token = strtolower((string) Str::uuid());
             $request->save();
         }
         return $request->binding_token;
@@ -136,21 +139,28 @@ class HockeyListingPaymentService
 
         $source = $receipt['source'];
 
-        // iOS StoreKit2: decode the JWS receipt to (a) bind it to THIS listing's
-        // payment request via appAccountToken, and (b) dedup on the real transactionId
-        // — the client `purchase_id` is unreliable under SK2 (can arrive as "0").
+        // iOS StoreKit2: decode the JWS receipt — independent of $request — to
+        // (a) bind it to a listing's payment request via appAccountToken, (b) dedup
+        // on the real transactionId (the client `purchase_id` is unreliable under
+        // SK2 and can arrive as "0"), and (c) let the recovery path adopt the token.
         // Signature verification is a tracked follow-up (the SEAM below).
-        if ($source === 'ios' && $request) {
+        $decodedToken = null;
+        if ($source === 'ios') {
             $jws = $receipt['verification_data']['server_verification_data'] ?? null;
             $decoded = Sk2ReceiptDecoder::decode(is_string($jws) ? $jws : null);
             if ($decoded) {
-                if ($this->decider->bindingMismatch($decoded['app_account_token'] ?? null, $request->binding_token)) {
-                    return ['code' => 'binding_mismatch', 'http' => 422, 'payload' => [
-                        'message' => 'This receipt does not belong to this listing.',
-                    ]];
-                }
+                $decodedToken = $this->decider->normalizeToken($decoded['app_account_token'] ?? null);
                 if (!empty($decoded['transaction_id'])) {
                     $receipt['purchase_id'] = $decoded['transaction_id'];
+                }
+                // The receipt is bound to a SPECIFIC request via appAccountToken. If
+                // that is NOT this listing's current request, the store is replaying a
+                // stale/cross-listing transaction. Do NOT reject (that loops forever
+                // because the receipt can never be finished here) — root-reconcile it
+                // to the request that actually owns the token so the correct listing
+                // publishes, the payment is never lost, and the client finishes the txn.
+                if ($request && $this->decider->bindingMismatch($decodedToken, $request->binding_token)) {
+                    return $this->rootReconcile($decodedToken, $receipt, $source, $actor, $listing);
                 }
             }
         }
@@ -221,7 +231,7 @@ class HockeyListingPaymentService
                 if (!$fee) {
                     return ['code' => 'fee_missing', 'http' => 404, 'payload' => ['message' => 'Listing fee product not found or inactive.']];
                 }
-                $recovered = DB::transaction(function () use ($listing, $actor, $receipt, $source, $fee) {
+                $recovered = DB::transaction(function () use ($listing, $actor, $receipt, $source, $fee, $decodedToken) {
                     $request = V4PaymentRequest::create([
                         'payer_id' => $actor->id,
                         'player_id' => $listing->user_id,
@@ -229,6 +239,10 @@ class HockeyListingPaymentService
                         'amount_cents' => $fee->amount_cents,
                         'currency' => $fee->currency,
                         'status' => V4PaymentRequest::STATUS_PAYMENT_INITIATED,
+                        // Adopt the receipt's appAccountToken so this recovered request
+                        // OWNS the token; without a binding_token a future replay of the
+                        // same receipt would be unrecoverable (orphaned).
+                        'binding_token' => $decodedToken ?? strtolower((string) Str::uuid()),
                         'meta' => ['purpose' => 'hockey_listing', 'listing_id' => $listing->id, 'recovered' => true],
                     ]);
                     $listing->payment_request_id = $request->id;
@@ -294,21 +308,159 @@ class HockeyListingPaymentService
 
     private function recordSuccessTransaction(V4PaymentRequest $request, V4User $actor, array $receipt, string $source): V4PaymentTransaction
     {
-        return V4PaymentTransaction::create([
-            'payment_request_id' => $request->id,
-            'payer_id' => $actor->id,
-            'amount_cents' => $request->amount_cents,
-            'currency' => $request->currency,
-            'gateway' => $this->decider->gatewayForSource($source),
-            'gateway_reference' => $source . '_' . uniqid() . '_' . time(),
-            'status' => V4PaymentTransaction::STATUS_SUCCESS,
-            'purchase_id' => $receipt['purchase_id'] ?? null,
-            'source' => $source,
-            'verification_data' => $receipt['verification_data'] ?? null,
-            'store_status' => $receipt['store_status'] ?? null,
-            'transaction_date' => $receipt['transaction_date'] ?? null,
-            'payload' => $receipt['payload'] ?? null,
+        $purchaseId = $receipt['purchase_id'] ?? null;
+
+        // Idempotent fast path: if this receipt/request already has a success txn,
+        // return it without issuing an INSERT. This also protects the surrounding
+        // transaction: on Postgres a failed statement aborts the whole transaction,
+        // so issuing an INSERT that violates a unique index here would poison the
+        // outer transaction and the recovery SELECT below could no longer run.
+        $existing = $this->findExistingSuccessTransaction($request, $purchaseId, $source);
+        if ($existing) {
+            return $existing;
+        }
+
+        try {
+            // Wrap the INSERT in a NESTED transaction so Laravel issues a SAVEPOINT.
+            // A unique violation from a concurrent replay then rolls back only to the
+            // savepoint, leaving the outer transaction usable for the recovery lookup.
+            return DB::transaction(fn () => V4PaymentTransaction::create([
+                'payment_request_id' => $request->id,
+                'payer_id' => $actor->id,
+                'amount_cents' => $request->amount_cents,
+                'currency' => $request->currency,
+                'gateway' => $this->decider->gatewayForSource($source),
+                'gateway_reference' => $source . '_' . uniqid() . '_' . time(),
+                'status' => V4PaymentTransaction::STATUS_SUCCESS,
+                'purchase_id' => $purchaseId,
+                'source' => $source,
+                'verification_data' => $receipt['verification_data'] ?? null,
+                'store_status' => $receipt['store_status'] ?? null,
+                'transaction_date' => $receipt['transaction_date'] ?? null,
+                'payload' => $receipt['payload'] ?? null,
+            ]));
+        } catch (QueryException $e) {
+            // Concurrent replay won the insert race. The DB enforces dedup via
+            // partial unique indexes — (purchase_id, source) for real purchase ids,
+            // and one success per payment_request. Return the row that already won.
+            if (!$this->isUniqueViolation($e)) {
+                throw $e;
+            }
+            $existing = $this->findExistingSuccessTransaction($request, $purchaseId, $source);
+            if ($existing) {
+                return $existing;
+            }
+            throw $e;
+        }
+    }
+
+    private function isUniqueViolation(QueryException $e): bool
+    {
+        // 23505 = Postgres unique_violation; 23000 = generic SQLSTATE integrity constraint.
+        return in_array((string) $e->getCode(), ['23505', '23000'], true);
+    }
+
+    private function findExistingSuccessTransaction(V4PaymentRequest $request, ?string $purchaseId, string $source): ?V4PaymentTransaction
+    {
+        $byRequest = V4PaymentTransaction::where('payment_request_id', $request->id)
+            ->where('status', V4PaymentTransaction::STATUS_SUCCESS)
+            ->latest('id')
+            ->first();
+        if ($byRequest) {
+            return $byRequest;
+        }
+        if (!empty($purchaseId) && !in_array($purchaseId, ['0', ''], true)) {
+            return V4PaymentTransaction::where('purchase_id', $purchaseId)
+                ->where('source', $source)
+                ->latest('id')
+                ->first();
+        }
+        return null;
+    }
+
+    /**
+     * Reconcile a receipt whose appAccountToken belongs to a payment request other
+     * than the one on the current screen (a stale or cross-listing store replay).
+     * Always returns http 200 with a `terminal` flag so the client finishes the
+     * StoreKit transaction and the replay loop ends. Publishes the listing the
+     * receipt actually paid for, absorbs duplicates idempotently, or — when no
+     * request/listing owns the token — acknowledges it as orphaned and logs it for
+     * manual refund review. Never returns 422 (which would loop forever).
+     */
+    private function rootReconcile(string $token, array $receipt, string $source, V4User $actor, V4HockeyListing $screenListing): array
+    {
+        $ownerRequest = V4PaymentRequest::where('binding_token', $token)->latest('id')->first();
+
+        $ownerListing = null;
+        if ($ownerRequest) {
+            // The listing's payment_request_id is overwritten on re-initiate, so resolve
+            // via the request's recorded listing_id first, then fall back to the link.
+            $ownerListingId = data_get($ownerRequest->meta, 'listing_id');
+            $ownerListing = $ownerListingId
+                ? V4HockeyListing::find($ownerListingId)
+                : V4HockeyListing::where('payment_request_id', $ownerRequest->id)->first();
+        }
+
+        $ownerSuccessTxn = $ownerRequest
+            ? V4PaymentTransaction::where('payment_request_id', $ownerRequest->id)
+                ->where('status', V4PaymentTransaction::STATUS_SUCCESS)
+                ->exists()
+            : false;
+
+        $code = $this->decider->bindingReconcile([
+            'owner_found' => (bool) $ownerRequest,
+            'owner_listing_exists' => (bool) $ownerListing,
+            'owner_listing_published' => $ownerListing?->status === V4HockeyListing::STATUS_PUBLISHED,
+            'owner_success_txn_exists' => $ownerSuccessTxn,
         ]);
+
+        if ($code === HockeyListingPaymentDecider::RECON_BIND_ORPHAN) {
+            // Money was captured by the store but no listing claims this token (e.g.
+            // the listing was deleted, or the token is unknown). Acknowledge so the
+            // client stops replaying, and flag for manual refund/reconciliation.
+            Log::warning('hockey_listing.orphan_receipt', [
+                'binding_token' => $token,
+                'purchase_id' => $receipt['purchase_id'] ?? null,
+                'source' => $source,
+                'payer_id' => $actor->id,
+                'screen_listing_id' => $screenListing->id,
+                'owner_request_id' => $ownerRequest?->id,
+            ]);
+            return ['code' => $code, 'http' => 200, 'payload' => [
+                'terminal' => true,
+                'reconciled' => false,
+                'message' => 'This receipt does not belong to any active listing.',
+            ]];
+        }
+
+        if ($code === HockeyListingPaymentDecider::RECON_BIND_DUPLICATE) {
+            return ['code' => $code, 'http' => 200, 'payload' => [
+                'terminal' => true,
+                'reconciled' => true,
+                'message' => 'Payment already processed.',
+                'listing_id' => $ownerListing->id,
+                'listing_status' => $ownerListing->status,
+            ]];
+        }
+
+        // RECON_BIND_PUBLISH — record the txn against the OWNER request and publish ITS listing.
+        $txn = DB::transaction(function () use ($ownerRequest, $actor, $receipt, $source, $ownerListing) {
+            $recorded = $this->recordSuccessTransaction($ownerRequest, $actor, $receipt, $source);
+            $ownerRequest->markPaid();
+            $ownerListing->markPublished();
+            return $recorded;
+        });
+
+        return ['code' => $code, 'http' => 200, 'payload' => [
+            'terminal' => true,
+            'reconciled' => true,
+            'message' => 'Payment confirmed. Your listing is now live.',
+            'listing_id' => $ownerListing->id,
+            'listing_status' => $ownerListing->status,
+            'listed_at' => $ownerListing->listed_at,
+            'payment_request_id' => $ownerRequest->id,
+            'payment_transaction_id' => $txn->id,
+        ]];
     }
 
     public function status(V4HockeyListing $listing): array

--- a/tests/Unit/Payments/HockeyListingPaymentDeciderTest.php
+++ b/tests/Unit/Payments/HockeyListingPaymentDeciderTest.php
@@ -192,4 +192,71 @@ class HockeyListingPaymentDeciderTest extends TestCase
         $this->assertFalse($this->d->bindingMismatch('aaaa', null));
         $this->assertFalse($this->d->bindingMismatch('aaaa', ''));
     }
+
+    public function test_binding_mismatch_is_case_insensitive(): void
+    {
+        // Apple may upper/lower-case the appAccountToken UUID when round-tripping it;
+        // a legitimate same-request receipt must NOT be treated as a mismatch.
+        $uuid = '11111111-1111-4111-8111-111111111111';
+        $this->assertFalse($this->d->bindingMismatch(strtoupper($uuid), $uuid));
+        $this->assertFalse($this->d->bindingMismatch($uuid, strtoupper($uuid)));
+        $this->assertFalse($this->d->bindingMismatch("  $uuid  ", $uuid)); // surrounding whitespace
+        // genuinely different tokens still mismatch
+        $this->assertTrue($this->d->bindingMismatch('AAAA', 'bbbb'));
+    }
+
+    public function test_normalize_token(): void
+    {
+        $this->assertNull($this->d->normalizeToken(null));
+        $this->assertNull($this->d->normalizeToken(''));
+        $this->assertNull($this->d->normalizeToken('   '));
+        $this->assertSame('abc-123', $this->d->normalizeToken('  ABC-123 '));
+    }
+
+    private function reconBase(array $over = []): array
+    {
+        return array_merge([
+            'owner_found' => true,
+            'owner_listing_exists' => true,
+            'owner_listing_published' => false,
+            'owner_success_txn_exists' => false,
+        ], $over);
+    }
+
+    public function test_binding_reconcile_orphan_when_no_owner_request(): void
+    {
+        $this->assertSame(
+            HockeyListingPaymentDecider::RECON_BIND_ORPHAN,
+            $this->d->bindingReconcile($this->reconBase(['owner_found' => false]))
+        );
+    }
+
+    public function test_binding_reconcile_orphan_when_owner_listing_missing(): void
+    {
+        // e.g. the listing was soft-deleted after the receipt was bound to it.
+        $this->assertSame(
+            HockeyListingPaymentDecider::RECON_BIND_ORPHAN,
+            $this->d->bindingReconcile($this->reconBase(['owner_listing_exists' => false]))
+        );
+    }
+
+    public function test_binding_reconcile_duplicate_when_already_published_or_paid(): void
+    {
+        $this->assertSame(
+            HockeyListingPaymentDecider::RECON_BIND_DUPLICATE,
+            $this->d->bindingReconcile($this->reconBase(['owner_listing_published' => true]))
+        );
+        $this->assertSame(
+            HockeyListingPaymentDecider::RECON_BIND_DUPLICATE,
+            $this->d->bindingReconcile($this->reconBase(['owner_success_txn_exists' => true]))
+        );
+    }
+
+    public function test_binding_reconcile_publish_when_owner_listing_unpublished(): void
+    {
+        $this->assertSame(
+            HockeyListingPaymentDecider::RECON_BIND_PUBLISH,
+            $this->d->bindingReconcile($this->reconBase())
+        );
+    }
 }


### PR DESCRIPTION
A StoreKit2 receipt is bound to a payment request via appAccountToken == binding_token. A stale or cross-listing transaction (the listing fee is a single shared consumable) replayed against a different request failed the binding check and returned HTTP 422 "This receipt does not belong to this listing." The client never finished the transaction, so StoreKit replayed it forever - a permanent loop that also lost the payment.

Replace the 422 with a root-reconcile: look up the request that actually owns the token, publish that listing idempotently, and return 200 so the client finishes the transaction. When no request owns the token, acknowledge it as an orphan (200) and log it for manual refund review rather than looping.

- Decider: case-insensitive bindingMismatch (Apple may upper-case the UUID), normalizeToken(), and a pure bindingReconcile() decision.
- Service: decode the JWS independent of the current request; rootReconcile() on mismatch; idempotent recordSuccessTransaction (pre-check + savepoint insert so a unique violation cannot poison the surrounding Postgres transaction); CONFIRM_RECOVER_PUBLISH now persists a binding_token; tokens lowercased on write.
- Command: schedule hockey:reconcile-listings every 15m and add a row-locked, recency-bounded sweep that heals receipts already stranded via meta.listing_id.
- Tests: case-insensitivity, normalizeToken, and the reconcile matrix.