### PR TITLE
Events: date-only status/filters, multi-value league/team, fee-status…

### DIFF
--- a/app/Http/Controllers/V4/V4EventController.php
+++ b/app/Http/Controllers/V4/V4EventController.php
@@ -27,6 +27,15 @@ class V4EventController extends Controller
         return response()->json(['success' => true, 'data' => V4EventType::activeNames()]);
     }
 
+    /**
+     * Global platform-fee switch, so the create wizard can label its CTA
+     * "Publish" (fee off) vs "Pay & Publish" (fee on) before submitting.
+     */
+    public function feeStatus(): JsonResponse
+    {
+        return response()->json(['success' => true, 'data' => ['platform_fee_enabled' => \App\Services\Payments\EventPaymentService::feeEnabled()]]);
+    }
+
     public function store(Request $request): JsonResponse
     {
         try {
@@ -59,8 +68,10 @@ class V4EventController extends Controller
                 'scout_leagues' => 'nullable|array',
                 'positions' => 'nullable|array',
                 'birth_years' => 'nullable|array',
-                'league' => 'nullable|string',
-                'team' => 'nullable|string',
+                'league' => 'nullable|array',
+                'league.*' => 'string',
+                'team' => 'nullable|array',
+                'team.*' => 'string',
                 'media' => 'nullable|array|max:10',
                 'media.*' => 'file|max:102400',
                 'media_types' => 'nullable|array',
@@ -136,6 +147,46 @@ class V4EventController extends Controller
                     }
                 });
             }
+        }
+        if ($div = $request->input('age_division')) {
+            $q->where('age_division', $div);
+        }
+        foreach (['league', 'team'] as $col) {
+            $vals = (array) $request->input($col, []);
+            if ($vals) {
+                $q->where(function ($w) use ($col, $vals) {
+                    foreach ($vals as $v) {
+                        $w->orWhereJsonContains($col, $v);
+                    }
+                });
+            }
+        }
+        // Age-range overlap: keep events whose [age_min, age_max] intersects the
+        // selected range. A null event bound is open-ended (matches anything).
+        if (($selMin = $request->input('age_min')) !== null) {
+            $q->where(function ($w) use ($selMin) {
+                $w->whereNull('age_max')->orWhere('age_max', '>=', (int) $selMin);
+            });
+        }
+        if (($selMax = $request->input('age_max')) !== null) {
+            $q->where(function ($w) use ($selMax) {
+                $w->whereNull('age_min')->orWhere('age_min', '<=', (int) $selMax);
+            });
+        }
+        $birthYears = (array) $request->input('birth_years', []);
+        if ($birthYears) {
+            $q->where(function ($w) use ($birthYears) {
+                foreach ($birthYears as $y) {
+                    $w->orWhereJsonContains('birth_years', (int) $y);
+                }
+            });
+        }
+        // Date window filters the event's start day (all-day → compare by date).
+        if ($from = $request->input('date_from')) {
+            $q->whereDate('start_at', '>=', $from);
+        }
+        if ($to = $request->input('date_to')) {
+            $q->whereDate('start_at', '<=', $to);
         }
         $tab = $request->input('tab', 'ongoing');
         // Events are all-day (date-only picker → end_at stored at midnight), so an
@@ -251,8 +302,10 @@ class V4EventController extends Controller
                 'scout_leagues' => 'nullable|array',
                 'positions' => 'nullable|array',
                 'birth_years' => 'nullable|array',
-                'league' => 'nullable|string',
-                'team' => 'nullable|string',
+                'league' => 'nullable|array',
+                'league.*' => 'string',
+                'team' => 'nullable|array',
+                'team.*' => 'string',
                 'add_media' => 'nullable|array',
                 'add_media.*' => 'file|max:102400',
                 'add_media_types' => 'nullable|array',
@@ -425,8 +478,8 @@ class V4EventController extends Controller
             'scout_leagues' => $e->scout_leagues ?? [],
             'positions' => $e->positions ?? [],
             'birth_years' => $e->birth_years ?? [],
-            'league' => $e->league,
-            'team' => $e->team,
+            'league' => $e->league ?? [],
+            'team' => $e->team ?? [],
             'special_qualification' => $e->special_qualification,
             'coordinator_name' => $e->coordinator_name,
             'business_name' => $e->business_name,

--- a/app/Models/V4Event.php
+++ b/app/Models/V4Event.php
@@ -47,6 +47,8 @@ class V4Event extends Model
         'scout_leagues' => 'array',
         'positions' => 'array',
         'birth_years' => 'array',
+        'league' => 'array',
+        'team' => 'array',
     ];
 
     public function creator()

--- a/database/migrations/2026_08_26_000000_change_v4_events_league_team_to_jsonb.php
+++ b/database/migrations/2026_08_26_000000_change_v4_events_league_team_to_jsonb.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+// league/team were single strings; events now support multiple (parity with
+// profile chips input). Convert to jsonb arrays, wrapping any existing scalar
+// value as a one-element array so no data is lost.
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE v4_events ALTER COLUMN league TYPE jsonb USING CASE WHEN league IS NULL OR league = '' THEN NULL ELSE to_jsonb(ARRAY[league]) END");
+        DB::statement("ALTER TABLE v4_events ALTER COLUMN team TYPE jsonb USING CASE WHEN team IS NULL OR team = '' THEN NULL ELSE to_jsonb(ARRAY[team]) END");
+    }
+
+    public function down(): void
+    {
+        // Collapse back to the first array element (lossy if multiple were set).
+        DB::statement("ALTER TABLE v4_events ALTER COLUMN league TYPE varchar(255) USING (league->>0)");
+        DB::statement("ALTER TABLE v4_events ALTER COLUMN team TYPE varchar(255) USING (team->>0)");
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -306,6 +306,7 @@ Route::prefix('v4')->group(function () {
     Route::prefix('events')->group(function () {
         Route::get('/', [V4EventController::class, 'index']);
         Route::get('types', [V4EventController::class, 'types']);
+        Route::get('fee-status', [V4EventController::class, 'feeStatus']);
     });
 
     // Portfolio share link — public open logging (fired by link.drafthouselabs.com)

--- a/tests/Feature/Event/BrowseEventTest.php
+++ b/tests/Feature/Event/BrowseEventTest.php
@@ -87,6 +87,48 @@ class BrowseEventTest extends TestCase
         $this->assertCount(0, $completed->json('data'), 'same-day event must not be completed');
     }
 
+    public function test_age_range_filter_overlaps_not_exact(): void
+    {
+        $me = $this->makeUser();
+        $owner = $this->makeUser();
+        $this->publishedEvent($owner, ['name' => 'Youth', 'age_min' => 13, 'age_max' => 45]);
+        $this->publishedEvent($owner, ['name' => 'Masters', 'age_min' => 80, 'age_max' => 100]);
+
+        // Selecting 82-100 must exclude the 13-45 event, include the 80-100 one.
+        $res = $this->withHeaders($this->authAs($me))
+            ->getJson('/api/v4/events?age_min=82&age_max=100');
+        $res->assertStatus(200);
+        $names = array_column($res->json('data'), 'name');
+        $this->assertContains('Masters', $names);
+        $this->assertNotContains('Youth', $names);
+    }
+
+    public function test_league_filter_multi_value(): void
+    {
+        $me = $this->makeUser();
+        $owner = $this->makeUser();
+        // league is now a multi-value jsonb array (parity with profile chips).
+        $this->publishedEvent($owner, ['name' => 'AHLteam', 'league' => ['AHL', 'ECHL']]);
+        $this->publishedEvent($owner, ['name' => 'NHLteam', 'league' => ['NHL']]);
+
+        $res = $this->withHeaders($this->authAs($me))
+            ->getJson('/api/v4/events?'.http_build_query(['league' => ['AHL']]));
+        $res->assertStatus(200);
+        $names = array_column($res->json('data'), 'name');
+        $this->assertSame(['AHLteam'], $names);
+    }
+
+    public function test_fee_status_reflects_admin_switch(): void
+    {
+        \App\Services\Payments\EventPaymentService::setFeeEnabled(false);
+        $this->getJson('/api/v4/events/fee-status')
+            ->assertStatus(200)->assertJsonPath('data.platform_fee_enabled', false);
+
+        \App\Services\Payments\EventPaymentService::setFeeEnabled(true);
+        $this->getJson('/api/v4/events/fee-status')
+            ->assertStatus(200)->assertJsonPath('data.platform_fee_enabled', true);
+    }
+
     public function test_my_events_same_day_is_ongoing(): void
     {
         $me = $this->makeUser();


### PR DESCRIPTION
… endpoint

- Classify ongoing/completed and join gates by date only (all-day events).
- Browse gains age-range overlap, age division, league, team, birth-year and date-window filters; league/team migrated string->jsonb (multi-value parity with profile chips) with json-contains matching.
- Public events/fee-status endpoint so the create wizard can label its CTA.
- Browse orders newest-created first.
- Tests: age overlap, league multi-value, date, fee-status, same-day cases.